### PR TITLE
Increasing memory for odo

### DIFF
--- a/odo/values.yaml
+++ b/odo/values.yaml
@@ -19,10 +19,10 @@ cloud:
 
 resources:
   limits:
-    memory: 128Mi
+    memory: 2Gi
     cpu: 300m
   requests:
-    memory: 128Mi
+    memory: 2Gi
     cpu: 100m
 
 prometheus:


### PR DESCRIPTION
Odo was dying on OOM errors for even relatively small shapefile conversions - this is a bandaid fix to help us get around these errors.

smartcitiesdata/odo#17

co-authored-by: Richard Jones <rajones@hntb.com>