### PR TITLE
Fixing andi hostname

### DIFF
--- a/andi/templates/deployment.yaml
+++ b/andi/templates/deployment.yaml
@@ -63,3 +63,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: NODE_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name


### PR DESCRIPTION
The vm_args that distillery uses to release an app are expecting the $NODE_IP to be in the container environment variables in order to set a proper hostname for the erlang node.