### PR TITLE
Adding andi liveview salt secret to chart

### DIFF
--- a/andi/Chart.yaml
+++ b/andi/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 1.1.2
+version: 1.2.0

--- a/andi/templates/deployment.yaml
+++ b/andi/templates/deployment.yaml
@@ -71,3 +71,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: LIVEVIEW_SALT
+            valueFrom:
+              secretKeyRef:
+                name: andi_lv_salt
+                key: salt

--- a/andi/templates/secrets.yaml
+++ b/andi/templates/secrets.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.secrets.live_view.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: andi_lv_salt
+type:
+  Opaque
+data:
+  salt: {{ .Values.secrets.live_view.value }}
+{{- end }}

--- a/andi/values.yaml
+++ b/andi/values.yaml
@@ -23,6 +23,11 @@ service:
   port: 80
   targetPort: 80
 
+secrets:
+  live_view:
+    enable: true
+    value: "dev_only_enable_false_and_define_out_of_source_in_prod"
+
 ingress:
   enabled: false
   scheme: ""


### PR DESCRIPTION
Adds the ability to define a signing salt environment variable for the andi chart and provides a default value so the app doesn't blow up in a development environment if the secret isn't already injected into the cluster by other, out-of-band means.