### PR TITLE
Bumping vault version because odo is gone

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A custom chart for the vault secrets engine in support of the UrbanOS platform.
 name: vault
-version: 1.3.1
+version: 1.3.2
 sources:
 - https://github.com/hashicorp/vault


### PR DESCRIPTION
## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
