### PR TITLE
Added quotes for require-api-key env var

### DIFF
--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.4.7
+version: 1.4.8
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/README.md
+++ b/charts/discovery-api/README.md
@@ -1,6 +1,6 @@
 # discovery-api
 
-![Version: 1.4.7](https://img.shields.io/badge/Version-1.4.7-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 1.4.8](https://img.shields.io/badge/Version-1.4.8-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 A middleware layer to connect data consumers with the data sources
 

--- a/charts/discovery-api/templates/deployment.yaml
+++ b/charts/discovery-api/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           - name: RAPTOR_URL
             value: {{ quote .Values.global.auth.raptor_url }}
           - name: REQUIRE_API_KEY
-            value: {{ .Values.global.require_api_key }}
+            value: {{ quote .Values.global.require_api_key }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/charts/discovery-streams/Chart.yaml
+++ b/charts/discovery-streams/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamically find kafka topics and makes available corresponding channels on a public websocket
 name: discovery-streams
-version: 1.1.6
+version: 1.1.7
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_streams

--- a/charts/discovery-streams/README.md
+++ b/charts/discovery-streams/README.md
@@ -1,6 +1,6 @@
 # discovery-streams
 
-![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Dynamically find kafka topics and makes available corresponding channels on a public websocket
 

--- a/charts/discovery-streams/templates/deployment.yaml
+++ b/charts/discovery-streams/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: RAPTOR_URL
           value: {{ quote .Values.global.auth.raptor_url }}
         - name: REQUIRE_API_KEY
-          value: {{ .Values.global.require_api_key }}
+          value: {{ quote .Values.global.require_api_key }}
         - name: METRICS_PORT
           value: {{ quote .Values.monitoring.targetPort }}
         - name: NAMESPACE

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -7,10 +7,10 @@ dependencies:
   version: 2.3.1
 - name: discovery-api
   repository: file://../discovery-api
-  version: 1.4.7
+  version: 1.4.8
 - name: discovery-streams
   repository: file://../discovery-streams
-  version: 1.1.6
+  version: 1.1.7
 - name: discovery-ui
   repository: file://../discovery-ui
   version: 1.5.5
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:f77218e877c43d8022a995479d988ef3b4798fab6c831a5f555997245ee0a95b
-generated: "2022-11-17T10:32:26.334988-05:00"
+digest: sha256:092117a2db3f9f42c552f1c2bf9f79612094d334dde24539acde765550df868a
+generated: "2022-11-17T11:38:57.382431-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.14
+version: 1.13.15
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.14](https://img.shields.io/badge/Version-1.13.14-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.15](https://img.shields.io/badge/Version-1.13.15-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## Description

Added quotes for require-api-key env var

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
